### PR TITLE
Tell an admin when a query failed instead of showing nothing

### DIFF
--- a/components/admin/AdminError.tsx
+++ b/components/admin/AdminError.tsx
@@ -1,0 +1,29 @@
+import { ErrorAlert } from '@/components/Alert'
+import Button from '@/components/Button'
+
+/**
+ * What an admin page shows when a query fails outright.
+ *
+ * Only a real failure reaches this: util/api.ts turns a 403 into
+ * AdminAccessError, which useAdminAccess handles, and returns null for a 404
+ * so the pages keep their own "not found" copy. What is left is the server or
+ * the network, so it is worth offering another go -- admin queries set
+ * `retry: false`, which means nothing tries again unless the person asks.
+ *
+ * Says explicitly that access is not the problem. The dashboard's other
+ * failure state is a revoked admin, and an unqualified error here would read
+ * as that.
+ */
+export default function AdminError({ onRetry }: { onRetry: () => void }) {
+	return (
+		<ErrorAlert title="Could not load this data">
+			<p>
+				Something went wrong on our end -- this is not a permissions problem,
+				your admin access is fine.
+			</p>
+			<Button type="button" onClick={onRetry} size="sm" color="utility">
+				Try again
+			</Button>
+		</ErrorAlert>
+	)
+}

--- a/pages/admin/[formKey].tsx
+++ b/pages/admin/[formKey].tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router'
 import { useQuery } from '@tanstack/react-query'
 import AdminGate from '@/components/AdminGate'
 import useAdminAccess from '@/components/admin/useAdminAccess'
+import AdminError from '@/components/admin/AdminError'
 import Button from '@/components/Button'
 import SubmissionsTable from '@/components/admin/SubmissionsTable'
 import { FormTabs, YearSelect } from '@/components/admin/Controls'
@@ -103,7 +104,9 @@ export default function Page() {
 				</div>
 			</div>
 
-			{revoked ? null : submissions.isPending ? (
+			{revoked ? null : submissions.isError ? (
+				<AdminError onRetry={() => submissions.refetch()} />
+			) : submissions.isPending ? (
 				<div className="mt-6 px-6 py-12 text-center text-sm text-gray-500">
 					Loading {noun}…
 				</div>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { useQuery } from '@tanstack/react-query'
 import AdminGate from '@/components/AdminGate'
 import useAdminAccess from '@/components/admin/useAdminAccess'
+import AdminError from '@/components/admin/AdminError'
 import { YearSelect } from '@/components/admin/Controls'
 import { useSessionStatus } from '@/lib/auth-client'
 import { getAdminCounts } from '@/util/api'
@@ -24,7 +25,7 @@ export default function Page() {
 		retry: false,
 	})
 
-	useAdminAccess(counts.error)
+	const revoked = useAdminAccess(counts.error)
 
 	const rows = counts.data?.counts ?? []
 	const years = rows.map((row) => row.year)
@@ -54,6 +55,10 @@ export default function Page() {
 					/>
 				</div>
 			</div>
+
+			{counts.isError && !revoked ? (
+				<AdminError onRetry={() => counts.refetch()} />
+			) : null}
 
 			<dl className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
 				{FORM_KEYS.map((formKey) => (

--- a/pages/admin/user/[userId].tsx
+++ b/pages/admin/user/[userId].tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { useQuery } from '@tanstack/react-query'
 import AdminGate from '@/components/AdminGate'
 import useAdminAccess from '@/components/admin/useAdminAccess'
+import AdminError from '@/components/admin/AdminError'
 import {
 	Card,
 	CardHeader,
@@ -151,7 +152,9 @@ export default function Page() {
 				← {backLabel}
 			</Link>
 
-			{revoked ? null : detail.isPending ? (
+			{revoked ? null : detail.isError ? (
+				<AdminError onRetry={() => detail.refetch()} />
+			) : detail.isPending ? (
 				<p className="mt-6 text-sm text-gray-500">Loading…</p>
 			) : !submitter || !data ? (
 				<div className="mt-6">

--- a/util/api.ts
+++ b/util/api.ts
@@ -98,11 +98,19 @@ export async function getNonPrContributions(): Promise<NonPrContributionsRespons
 /**
  * Admin reads. These hit /api/admin/*.
  *
- * A 403 throws rather than returning null, because "you no longer have access"
- * and "there is nothing here" have to look different: returning null made
- * react-query report success-with-no-data, so a revoked admin saw an empty
- * dashboard instead of being told. See components/admin/useAdminAccess.ts.
- * Every other failure still returns null, like the member-facing helpers above.
+ * Unlike the member-facing helpers above, these do not flatten every failure
+ * to null. react-query settles a null as success-with-no-data, and an admin
+ * page cannot tell that apart from an empty table -- so a failure rendered as
+ * "No submissions yet" or "Not found", which is a lie about someone else's
+ * data. Three outcomes instead:
+ *
+ * - 403 throws AdminAccessError. Access was revoked mid-session; see
+ *   components/admin/useAdminAccess.ts, which refetches the session so
+ *   AdminGate can say so.
+ * - 404 returns null. This is an answer, not a failure: no member matches that
+ *   address. The pages still render their own "not found" copy for it.
+ * - Anything else throws. The server or the network broke, and the page says
+ *   that rather than inventing an empty result.
  */
 export class AdminAccessError extends Error {
 	constructor() {
@@ -126,8 +134,11 @@ export async function getAdminCounts(): Promise<AdminCountsResponse> {
 	if (response.status === 403) {
 		throw new AdminAccessError()
 	}
-	if (!response.ok) {
+	if (response.status === 404) {
 		return null
+	}
+	if (!response.ok) {
+		throw new Error(`Admin request failed with ${response.status}`)
 	}
 	return response.json()
 }
@@ -155,8 +166,11 @@ export async function getAdminSubmissions(
 	if (response.status === 403) {
 		throw new AdminAccessError()
 	}
-	if (!response.ok) {
+	if (response.status === 404) {
 		return null
+	}
+	if (!response.ok) {
+		throw new Error(`Admin request failed with ${response.status}`)
 	}
 	return response.json()
 }
@@ -180,8 +194,11 @@ export async function getAdminSubmitter(
 	if (response.status === 403) {
 		throw new AdminAccessError()
 	}
-	if (!response.ok) {
+	if (response.status === 404) {
 		return null
+	}
+	if (!response.ok) {
+		throw new Error(`Admin request failed with ${response.status}`)
 	}
 	return response.json()
 }


### PR DESCRIPTION
Stacked on #43 — base is `feat/admin-dashboard`, so merge that one first.

Picks up the loose end from the CodeRabbit review on #43, and finishes what `4a3dcb3` started there.

## The problem

`4a3dcb3` fixed the 403 case: a revoked admin was seeing an empty dashboard instead of being told. Every other failure was still flattened to `null` in `util/api.ts`, with the same consequence — react-query settles a `null` as success-with-no-data, so a 500 or a dropped connection rendered **"No submissions yet"** or **"Not found"**.

That is a lie about other people's data, and the sort an admin acts on. "There were no maintainer signups in 2026" is a conclusion someone might reasonably draw and then repeat.

## The change

The admin fetchers sort outcomes into three instead of two:

| Status | Result | Why |
| --- | --- | --- |
| 403 | throws `AdminAccessError` | unchanged — `useAdminAccess` refetches the session so `AdminGate` can say access was revoked |
| 404 | returns `null` | genuinely an answer, not a failure. The pages keep their own "no member matches that address" copy |
| anything else | throws | the server or the network broke; `isError` goes true and the page says so |

`AdminError` is the shared screen, built on the existing `ErrorAlert` that `Forms.tsx` already uses for a failed submit — no new error styling.

Two deliberate details:

- **It has a Try again button.** Admin queries set `retry: false` (a 403 is a settled answer, and retrying meant three more with a GitHub resync behind each). So a transient 500 has nothing to recover it unless the person asks.
- **It says outright that access is not the problem.** The dashboard's only other failure state is a revoked admin, and an unqualified error would read as that.

Each page checks `isError` ahead of `isPending` and its own empty state, and stays behind the `revoked` check so a 403 still routes to `AdminGate` rather than rendering both.

## Verification

`pnpm typecheck` and `pnpm build` pass; prettier clean. Not exercised in a browser — reproducing it wants a forced 5xx from the admin routes, and there are no tests over these pages.